### PR TITLE
Update CustomDateTimePicker.xaml

### DIFF
--- a/MD_DatePickerTest.Controls/CustomDateTimePicker.xaml
+++ b/MD_DatePickerTest.Controls/CustomDateTimePicker.xaml
@@ -17,7 +17,6 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <DatePicker />
         <DatePicker Margin="0,0,2.5,0" 
                     SelectedDateFormat="Short" 
                     SelectedDate="{Binding ElementName=customDateTimePicker, Path=SelectedDateTime, Mode=TwoWay, Converter={StaticResource DateConverter}}" />


### PR DESCRIPTION
Removing duplicate `DatePicker`. The one just below this has a margin which is why these appear to be a shadow or slightly offset from each other.